### PR TITLE
resolves "Module not found" error during external import

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "exports": {
     ".": {
       "require": "./lib/index.cjs",
-      "default": "./lib/index.js",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
Full error:
"Module not found: Default condition should be last one"

discovered while trying to use [i-am-bee/bee-agent-framework](https://github.com/i-am-bee/bee-agent-framework)